### PR TITLE
fix: Prevent map from shrinking on click

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,31 +20,31 @@
             margin: 0;
             padding: 0;
             font-family: Arial, sans-serif;
+            overflow: hidden; /* Zabráni nechceným posuvníkom */
+        }
+
+        body {
             display: flex;
-            flex-direction: row; /* Upravené pre bočný panel */
         }
 
         #main-content {
             flex-grow: 1;
             display: flex;
             flex-direction: column;
-            height: 100vh;
         }
 
         /* Kontajner pre mapu */
         #map {
-            flex-grow: 1; /* Mapa sa roztiahne */
-            width: 100%;
-            cursor: crosshair;
+            flex-grow: 1; /* Mapa sa roztiahne, aby vyplnila zvyšný priestor */
         }
 
         /* Informačný panel v hornej časti */
         #info {
+            flex-shrink: 0; /* Zabraňuje zmenšovaniu informačného panelu */
             background-color: rgba(255, 255, 255, 0.85);
             padding: 15px;
             text-align: center;
             border-bottom: 1px solid #ccc;
-            /* z-index: 1000; už nie je potrebný pri tomto usporiadaní */
         }
         
         h1 {


### PR DESCRIPTION
This commit addresses a CSS issue where the Leaflet map would shrink horizontally within its flexbox container whenever a popup was opened.

The fix refactors the main layout's CSS to use a more robust and simplified flexbox model. By removing explicit heights on the flex children and relying on the parent `body` to constrain the layout, the browser can now correctly calculate and maintain the map's width even when its internal content changes.